### PR TITLE
update libesphttpd submodule to point to working version from jkent

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,6 +1,6 @@
 [submodule "components/libesphttpd"]
 	path = components/libesphttpd
-	url = https://github.com/chmorgan/libesphttpd.git
+	url = https://github.com/jkent/libesphttpd.git
 [submodule "components/espfs"]
 	path = components/espfs
 	url = https://github.com/jkent/esp32-espfs.git


### PR DESCRIPTION
Thanks for this updated fork!
When I first checked this out, libesphttpd submodule was pointing to the older chmorgan version that doesn't compile w/ esf-idf v4.0-beta1

Fixing this in case someone else stumbles on it :)